### PR TITLE
Support installing go-project via npm and GitHub packages

### DIFF
--- a/go-project/.gitignore
+++ b/go-project/.gitignore
@@ -1,1 +1,2 @@
 dist/
+node_modules/

--- a/go-project/README.md
+++ b/go-project/README.md
@@ -1,4 +1,37 @@
 # go-project
+## Installing the CLI
+Some ways of installing the CLI:
+* `wget` the desired binary from GitHub Releases
+
+```bash
+$ wget -c https://github.com/urianchang/sandbox-1/releases/download/cli-0.0.1/go-project_0.0.1_Darwin-x86_64.tar.gz -P /tmp/go-project && \
+tar -xzf /tmp/go-project/go-project_0.0.1_Darwin-x86_64.tar.gz -C /tmp/go-project && \
+cp /tmp/go-project/hello-world /usr/local/bin && \
+rm -rf /tmp/go-project
+```
+
+* `npm install` from the GitHub npm registry.
+
+```bash
+# You'll need to include this in your ~/.npmrc
+$ cat ~/.npmrc
+@urianchang:registry=https://npm.pkg.github.com/
+
+$ npm install -g @urianchang/go-project
+
+> @urianchang/go-project@0.0.1 preuninstall /usr/local/lib/node_modules/@urianchang/go-project
+> node postinstall.js uninstall
+
+Uninstalled cli successfully
+
+> @urianchang/go-project@0.0.1 postinstall /usr/local/lib/node_modules/@urianchang/go-project
+> node postinstall.js install
+
+Copying the relevant binary for your platform darwin
+Installed cli successfully
++ @urianchang/go-project@0.0.1
+updated 1 package in 2.168s
+```
 
 ## Release Process
 ### Prerequisites
@@ -41,7 +74,7 @@ export GITHUB_TOKEN="GH_API_Token"
 
 4. Commit and push your changes to the upstream repository.
 5. Create a GitHub Pull Request (PR) and seek approval.
-6. When the PR has been approved, create and push a git tab with the format: `cli-<version>`
+6. When the PR has been approved, create and push a git tag with the format: `cli-<version>`
 
 ```bash
 > git tag -a cli-0.0.1 -m "CLI release v0.0.1"

--- a/go-project/package-lock.json
+++ b/go-project/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@urianchang/go-project",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    }
+  }
+}

--- a/go-project/package.json
+++ b/go-project/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@urianchang/go-project",
+  "version": "0.0.1",
+  "description": "Testing CLI distribution",
+  "main": "index.js",
+  "scripts": {
+    "postinstall": "node postinstall.js install",
+    "preuninstall": "node postinstall.js uninstall"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/urianchang/sandbox-1.git"
+  },
+  "author": "Urian",
+  "license": "UNLICENSED",
+  "bugs": {
+    "url": "https://github.com/urianchang/sandbox-1/issues"
+  },
+  "goBinary": {
+    "name": "hello-world",
+    "path": "./bin"
+  },
+  "homepage": "https://github.com/urianchang/sandbox-1/blob/master/go-project/README.md",
+  "files": [
+    "dist",
+    "postinstall.js"
+  ],
+  "dependencies": {
+    "mkdirp": "^1.0.4"
+  }
+}

--- a/go-project/package.json
+++ b/go-project/package.json
@@ -7,6 +7,9 @@
     "postinstall": "node postinstall.js install",
     "preuninstall": "node postinstall.js uninstall"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/urianchang/sandbox-1.git"
@@ -22,7 +25,7 @@
   },
   "homepage": "https://github.com/urianchang/sandbox-1/blob/master/go-project/README.md",
   "files": [
-    "dist",
+    "dist/**",
     "postinstall.js"
   ],
   "dependencies": {

--- a/go-project/postinstall.js
+++ b/go-project/postinstall.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// Referenced from: https://blog.xendit.engineer/how-we-repurposed-npm-to-publish-and-distribute-our-go-binaries-for-internal-cli-23981b80911b
+
+"use strict";
+// Thanks to author of https://github.com/sanathkr/go-npm, we were able to modify his code to work with private packages
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var path = require('path'),
+    mkdirp = require('mkdirp'),
+    fs = require('fs');
+
+// Mapping from Node's `process.arch` to Golang's `$GOARCH`
+var ARCH_MAPPING = {
+    "ia32": "386",
+    "x64": "amd64",
+    "arm": "arm"
+};
+
+// Mapping between Node's `process.platform` to Golang's
+var PLATFORM_MAPPING = {
+    "darwin": "darwin",
+    "linux": "linux",
+    "win32": "windows",
+    "freebsd": "freebsd"
+};
+
+async function getInstallationPath() {
+
+    // `npm bin` will output the path where binary files should be installed
+    const value = await execShellCommand("npm bin -g");
+        var dir = null;
+        if (!value || value.length === 0) {
+
+            // We couldn't infer path from `npm bin`. Let's try to get it from
+            // Environment variables set by NPM when it runs.
+            // npm_config_prefix points to NPM's installation directory where `bin` folder is available
+            // Ex: /Users/foo/.nvm/versions/node/v4.3.0
+            var env = process.env;
+            if (env && env.npm_config_prefix) {
+                dir = path.join(env.npm_config_prefix, "bin");
+            }
+        } else {
+            dir = value.trim();
+        }
+
+        await mkdirp(dir);
+        return dir;
+}
+
+async function verifyAndPlaceBinary(binName, binPath, callback) {
+    if (!fs.existsSync(path.join(binPath, binName))) return callback('Downloaded binary does not contain the binary specified in configuration - ' + binName);
+
+    // Get installation path for executables under node
+    const installationPath=  await getInstallationPath();
+    // Copy the executable to the path
+    fs.rename(path.join(binPath, binName), path.join(installationPath, binName),(err)=>{
+        if(!err){
+            console.info("Installed cli successfully");
+            callback(null);
+        }else{
+            callback(err);
+        }
+    });
+}
+
+function validateConfiguration(packageJson) {
+
+    if (!packageJson.version) {
+        return "'version' property must be specified";
+    }
+
+    if (!packageJson.goBinary || _typeof(packageJson.goBinary) !== "object") {
+        return "'goBinary' property must be defined and be an object";
+    }
+
+    if (!packageJson.goBinary.name) {
+        return "'name' property is necessary";
+    }
+
+    if (!packageJson.goBinary.path) {
+        return "'path' property is necessary";
+    }
+}
+
+function parsePackageJson() {
+    if (!(process.arch in ARCH_MAPPING)) {
+        console.error("Installation is not supported for this architecture: " + process.arch);
+        return;
+    }
+
+    if (!(process.platform in PLATFORM_MAPPING)) {
+        console.error("Installation is not supported for this platform: " + process.platform);
+        return;
+    }
+
+    var packageJsonPath = path.join(".", "package.json");
+    if (!fs.existsSync(packageJsonPath)) {
+        console.error("Unable to find package.json. " + "Please run this script at root of the package you want to be installed");
+        return;
+    }
+
+    var packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+    var error = validateConfiguration(packageJson);
+    if (error && error.length > 0) {
+        console.error("Invalid package.json: " + error);
+        return;
+    }
+
+    // We have validated the config. It exists in all its glory
+    var binName = packageJson.goBinary.name;
+    var binPath = packageJson.goBinary.path;
+    var version = packageJson.version;
+    if (version[0] === 'v') version = version.substr(1); // strip the 'v' if necessary v0.0.1 => 0.0.1
+
+    // Binary name on Windows has .exe suffix
+    if (process.platform === "win32") {
+        binName += ".exe";
+    }
+
+
+    return {
+        binName: binName,
+        binPath: binPath,
+        version: version
+    };
+}
+
+/**
+ * Reads the configuration from application's package.json,
+ * validates properties, copied the binary from the package and stores at
+ * ./bin in the package's root. NPM already has support to install binary files
+ * specific locations when invoked with "npm install -g"
+ *
+ *  See: https://docs.npmjs.com/files/package.json#bin
+ */
+var INVALID_INPUT = "Invalid inputs";
+async function install(callback) {
+
+    var opts = parsePackageJson();
+    if (!opts) return callback(INVALID_INPUT);
+    mkdirp.sync(opts.binPath);
+    console.info(`Copying the relevant binary for your platform ${process.platform}`);
+    const src= `./dist/go-project_${process.platform}_${ARCH_MAPPING[process.arch]}/${opts.binName}`;
+    await execShellCommand(`cp ${src} ${opts.binPath}/${opts.binName}`);
+    await verifyAndPlaceBinary(opts.binName, opts.binPath, callback);
+}
+
+async function uninstall(callback) {
+    var opts = parsePackageJson();
+        try {
+            const installationPath = await getInstallationPath();
+            fs.unlink(path.join(installationPath, opts.binName),(err)=>{
+                if(err){
+                    return callback(err);
+                }
+            });
+        } catch (ex) {
+            // Ignore errors when deleting the file.
+        }
+    console.info("Uninstalled cli successfully");
+    return callback(null);
+}
+
+// Parse command line arguments and call the right method
+var actions = {
+    "install": install,
+    "uninstall": uninstall
+};
+/**
+ * Executes a shell command and return it as a Promise.
+ * @param cmd {string}
+ * @return {Promise<string>}
+ */
+function execShellCommand(cmd) {
+    const exec = require('child_process').exec;
+    return new Promise((resolve, reject) => {
+        exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                console.warn(error);
+            }
+            resolve(stdout? stdout : stderr);
+        });
+    });
+}
+
+var argv = process.argv;
+if (argv && argv.length > 2) {
+    var cmd = process.argv[2];
+    if (!actions[cmd]) {
+        console.log("Invalid command. `install` and `uninstall` are the only supported commands");
+        process.exit(1);
+    }
+
+    actions[cmd](function (err) {
+        if (err) {
+            console.error(err);
+            process.exit(1);
+        } else {
+            process.exit(0);
+        }
+    });
+}


### PR DESCRIPTION
References:
* https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry
* https://blog.xendit.engineer/how-we-repurposed-npm-to-publish-and-distribute-our-go-binaries-for-internal-cli-23981b80911b